### PR TITLE
chore: add dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+updates: 
+  - commit-message: 
+      include: scope
+      prefix: chore
+    directory: /
+    labels: 
+      - dependencies
+    open-pull-requests-limit: 99
+    package-ecosystem: npm
+    reviewers:
+      - Hazmi35
+    schedule:
+      interval: daily
+      time: "06:00"
+      timezone: Asia/Jakarta
+    target-branch: main
+  - commit-message: 
+      include: scope
+      prefix: ci
+    directory: /
+    labels: 
+      - gh-actions
+      - dependencies
+    open-pull-requests-limit: 99
+    package-ecosystem: github-actions
+    reviewers:
+      - Hazmi35
+    schedule: 
+      interval: daily
+      time: "06:00"
+      timezone: Asia/Jakarta
+    target-branch: main
+version: 2


### PR DESCRIPTION
NOTE: This PR needs #1 to be merged first.

Who's gonna be the reviewer other than me?

We also need to create new labels for this, "gh-actions" and "dependencies.", "dependencies" should be blue, and "gh-actions" is green.